### PR TITLE
更新关于DNS分流的设置

### DIFF
--- a/docs/document/level-0/ch08-xray-clients.md
+++ b/docs/document/level-0/ch08-xray-clients.md
@@ -147,7 +147,7 @@
      // 3_分流设置
      // 所谓分流，就是将符合否个条件的流量，用指定`tag`的出站协议去处理（对应配置的5.x内容）
      "routing": {
-       "domainStrategy": "AsIs",
+       "domainStrategy": "IPIfNonMatch",
        "rules": [
          // 3.1 广告域名屏蔽
          {
@@ -172,9 +172,17 @@
            "type": "field",
            "domain": ["geosite:geolocation-!cn"],
            "outboundTag": "proxy"
-         }
+         },
          // 3.5 默认规则
          // 在Xray中，任何不符合上述路由规则的流量，都会默认使用【第一个outbound（5.1）】的设置，所以一定要把转发VPS的outbound放第一个
+         // 3.6 走国内"223.5.5.5"的DNS查询流量分流走direct出站
+         {
+            "type": "field",
+            "ip": [
+                "223.5.5.5"
+            ],
+            "outboundTag": "direct"
+         } 
        ]
      },
 


### PR DESCRIPTION

大佬好，我是看您的教程入门的。最近看了一些文档，发现教程当中关于DNS的设置可能有一些问题，我试着改了一下，不对请指正
1. "domainStrategy"策略设置为"AsIs"会忽略DNS服务器设置，此处改为"IPIfNonMatch"
2. 路由规则中没有配置DNS查询流量的出站规则，会导致所有DNS查询流量走默认的proxy出站，在某些情况可能返回不正确的结果.这里我是参考的[《漫谈各种黑科技式-dns-技术在代理环境中的应用》](https://tachyondevel.medium.com/%E6%BC%AB%E8%B0%88%E5%90%84%E7%A7%8D%E9%BB%91%E7%A7%91%E6%8A%80%E5%BC%8F-dns-%E6%8A%80%E6%9C%AF%E5%9C%A8%E4%BB%A3%E7%90%86%E7%8E%AF%E5%A2%83%E4%B8%AD%E7%9A%84%E5%BA%94%E7%94%A8-62c50e58cbd0)