### PR TITLE
修复流量信息的处理 reset 参数无效问题

### DIFF
--- a/docs/document/level-2/traffic_stats.md
+++ b/docs/document/level-2/traffic_stats.md
@@ -71,7 +71,7 @@ _XRAY=/usr/local/bin/xray
 apidata () {
     local ARGS=
     if [[ $1 == "reset" ]]; then
-      ARGS="reset: true"
+      ARGS="-reset=true"
     fi
     $_XRAY api statsquery --server=$_APISERVER "${ARGS}" \
     | awk '{


### PR DESCRIPTION
不知道修改的对不对，我看脚本中重置流量的参数好像不太对