### PR TITLE
Update ch07-xray-server.md

### DIFF
--- a/docs/document/level-0/ch07-xray-server.md
+++ b/docs/document/level-0/ch07-xray-server.md
@@ -280,6 +280,7 @@
             "security": "tls",
             "tlsSettings": {
               "certificates": [
+                "alpn": "http/1.1",
                 {
                   "certificateFile": "/home/vpsadmin/xray_cert/xray.crt",
                   "keyFile": "/home/vpsadmin/xray_cert/xray.key"


### PR DESCRIPTION
xray配置中的tlsSettings应该加上"alpn": "http/1.1"，否则按照教程【服务器优化之二：开启 HTTP 自动跳转 HTTPS】操作之后，网站无法正常访问，访问网站的时候会出现ERR_HTTP2_PROTOCOL_ERROR，但xray还是可以正常工作的。