### PR TITLE
Add the address field for warp.

### DIFF
--- a/docs/document/level-2/warp.md
+++ b/docs/document/level-2/warp.md
@@ -42,6 +42,10 @@ Endpoint = engage.cloudflareclient.com:2408
   "protocol": "wireguard",
   "settings": {
     "secretKey": "我的私钥",
+    "address": [
+        "172.16.0.2/32",
+        "2606:4700:110:8949:fed8:2642:a640:c8e1/128"
+    ],
     "peers": [
       {
         "publicKey": "Warp公钥",


### PR DESCRIPTION
In some cases, the outbound configuration for wireguard requires the addition of the 'address' field in order to establish a proper connection.  

It should be noted that the absence of the 'address' field configuration results in the inability to establish connections via domain names, only IP addresses can be used for connections.

This issue has been discussed previously: https://github.com/XTLS/Xray-core/issues/1385