### PR TITLE
Update tproxy_ipv4_and_ipv6.md

### DIFF
--- a/docs/document/level-2/tproxy_ipv4_and_ipv6.md
+++ b/docs/document/level-2/tproxy_ipv4_and_ipv6.md
@@ -173,7 +173,8 @@ title: TProxy 透明代理 (ipv4 and ipv6)
         "network": "udp",
         "outboundTag": "dns-out"
       },
-      { //使用了tcp+local查询dns，这段不写也行，但如果不是local模式需要写
+      {
+        //使用了tcp+local查询dns，这段不写也行，但如果不是local模式需要写
         "type": "field",
         "ip": ["119.29.29.29", "223.5.5.5"],
         "outboundTag": "direct"

--- a/docs/document/level-2/tproxy_ipv4_and_ipv6.md
+++ b/docs/document/level-2/tproxy_ipv4_and_ipv6.md
@@ -135,18 +135,18 @@ title: TProxy 透明代理 (ipv4 and ipv6)
   "dns": {
     "hosts": {
       "domain:googleapis.cn": "googleapis.com",
-      "dns.google": ["8.8.8.8", "8.8.4.4"],
+      "dns.google": "8.8.8.8",
       "你的VPS域名": "你的VSP IP" //如果 outbound 的 proxy 里 address 填的域名：希望代理走ipv4，这里 VPS IP 填VPS的ipv4, 希望代理走ipv6，这里VPS IP 填VPS的ipv6；outbound 的 proxy 里 address 填的 IP，这行不用写。
     },
     "servers": [
       "https://1.1.1.1/dns-query",
       {
-        "address": "tcp+local://119.29.29.29",
+        "address": "119.29.29.29",
         "domains": ["geosite:cn"],
         "expectIPs": ["geoip:cn"]
       },
       "https://dns.google/dns-query",
-      "tcp+local://223.5.5.5",
+      "223.5.5.5",
       "localhost"
     ]
   },
@@ -174,7 +174,6 @@ title: TProxy 透明代理 (ipv4 and ipv6)
         "outboundTag": "dns-out"
       },
       {
-        //使用了tcp+local查询dns，这段不写也行，但如果不是local模式需要写
         "type": "field",
         "ip": ["119.29.29.29", "223.5.5.5"],
         "outboundTag": "direct"
@@ -196,7 +195,7 @@ title: TProxy 透明代理 (ipv4 and ipv6)
       },
       {
         "type": "field",
-        "ip": ["1.1.1.1"],
+        "ip": ["1.1.1.1", "8.8.8.8"],
         "outboundTag": "proxy"
       },
       {


### PR DESCRIPTION
最近issue区感觉有不少dns的问题，也趁这个机会开debug对照文档狠狠的恶补了一波dns。
删除了fakedns，因为发现开fakedns并不生效，最后还是走localhost，徒增延迟，debug显示 skip DNS resolution for domain xxx.xxx at server FakeDNS。查了一下可能和这个issue 有关 （https://github.com/v2fly/v2ray-core/pull/879）但我看了一下xray的dns.go发现情况不太一样，水平不够就不pr了。
删除了routeOnly，文档里说除非可以获得正确解析，我这里解析不被污染，所以是正常的，但这个不普适，存在误导。
最后改了改dns配置，我自己是通了，看debug也很正常的走流程。
多说一点，dns代理拿到解析ip耗时大概就是ping延迟，hk sgp还好，阿迈利卡可能就得200ms左右了，还是有一丢丢可以感知到的，不过有缓存其实问题不大，只是如果fakedns可以开那还是有用的。
如果有不对的地方还请大佬指正。