### PR TITLE
Add documentation for the ReflectionService API

### DIFF
--- a/docs/config/api.md
+++ b/docs/config/api.md
@@ -86,6 +86,19 @@ API 接口配置提供了一些基于 [gRPC](https://grpc.io/)的 API 接口供�
 
 内置的数据统计服务，详见 [统计信息](./stats.md)。
 
+### ReflectionService
+
+支持 gRPC 客户端获取服务端的 API 列表。
+
+```bash
+$ grpcurl -plaintext localhost:10085 list
+grpc.reflection.v1alpha.ServerReflection
+v2ray.core.app.proxyman.command.HandlerService
+v2ray.core.app.stats.command.StatsService
+xray.app.proxyman.command.HandlerService
+xray.app.stats.command.StatsService
+```
+
 ## API 调用示例
 
 [Xray-API-documents](https://github.com/XTLS/Xray-API-documents) @crossfw

--- a/docs/en/config/api.md
+++ b/docs/en/config/api.md
@@ -86,6 +86,19 @@ API 接口配置提供了一些基于 [gRPC](https://grpc.io/)的 API 接口供�
 
 内置的数据统计服务，详见 [统计信息](./stats.md)。
 
+### ReflectionService
+
+支持 gRPC 客户端获取服务端的 API 列表。
+
+```bash
+$ grpcurl -plaintext localhost:10085 list
+grpc.reflection.v1alpha.ServerReflection
+v2ray.core.app.proxyman.command.HandlerService
+v2ray.core.app.stats.command.StatsService
+xray.app.proxyman.command.HandlerService
+xray.app.stats.command.StatsService
+```
+
 ## API 调用示例
 
 [Xray-API-documents](https://github.com/XTLS/Xray-API-documents) @crossfw


### PR DESCRIPTION
Xray supports listing the gRPC APIs through the ReflectionService that was previously implemented [here](https://github.com/v2fly/v2ray-core/pull/435), but it was never documented.

```bash
$ grpcurl -plaintext 127.0.0.1:10085 xray.app.stats.command.StatsService.QueryStats | jq
{
  "stat": [
    {
      "name": "inbound>>>api>>>traffic>>>uplink",
      "value": "9702"
    },
    {
      "name": "inbound>>>api>>>traffic>>>downlink",
      "value": "34551"
    },
    {
      "name": "outbound>>>direct>>>traffic>>>uplink",
      "value": "2143"
    },
    {
      "name": "outbound>>>direct>>>traffic>>>downlink",
      "value": "17215"
    }
  ]
}
```