### PR TITLE
fix: fix some wrong of leval-0

### DIFF
--- a/docs/document/level-0/ch07-xray-server.md
+++ b/docs/document/level-0/ch07-xray-server.md
@@ -279,7 +279,7 @@
             "network": "tcp",
             "security": "tls",
             "tlsSettings": {
-              "alpn": "http/1.1",
+              "alpn": ["h2", "http/1.1"],
               "certificates": [
                 {
                   "certificateFile": "/home/vpsadmin/xray_cert/xray.crt",

--- a/docs/document/level-0/ch08-xray-clients.md
+++ b/docs/document/level-0/ch08-xray-clients.md
@@ -41,7 +41,7 @@
 - 服务器【地址】: `a-name.yourdomain.com`
 - 服务器【端口】: `443`
 - 连接的【协议】: `vless`
-- 连接的【流控】: `xtls-rprx-direct` (direct 模式适合全平台，若是 Linux/安卓用户，可改成 `xtls-rprx-splice` 性能全开)
+- 连接的【流控】: `xtls-rprx-vision`
 - 连接的【验证】: `uuiduuid-uuid-uuid-uuiduuiduuid`
 - 连接的【安全】: `"allowInsecure": false`
 


### PR DESCRIPTION
1. 服务端的 `alpn` 如果只支持 http/1.1 是个非常明显的特征。现在大部分的网页服务器都有 h2。

2. 修复客户端填写的信息：服务端已改用 vision，客户端信息也要跟着修改。