### PR TITLE
修复三个参数类型不正确的问题

### DIFF
--- a/docs/config/transport.md
+++ b/docs/config/transport.md
@@ -176,15 +176,15 @@ Reality 是目前最安全的传输加密方案, 且外部看来流量类型和�
 
 一个字符串数组，指定了 TLS 握手时指定的 ALPN 数值。默认值为 `["h2", "http/1.1"]`。
 
-> `minVersion`: \[ string \]
+> `minVersion`: string
 
-minVersion 为可接受的最小 SSL/TLS 版本。
+minVersion 为可接受的最小 TLS 版本。
 
-> `maxVersion`: \[ string \]
+> `maxVersion`: string
 
-maxVersion 为可接受的最大 SSL/TLS 版本。
+maxVersion 为可接受的最大 TLS 版本。
 
-> `cipherSuites`: \[ string \]
+> `cipherSuites`: string
 
 CipherSuites 用于配置受支持的密码套件列表, 每个套件名称之间用:进行分隔.
 


### PR DESCRIPTION
我发现 TLSObject 中有三个参数被意外标记了数组类型，然后我照着抄配置我就报错了...

<details>

```console
Failed to start: main: failed to load config files: [config.json] > infra/conf/serial: failed to decode config: config.json > infra/conf/serial: failed to read
config file at line FAKEVALUE char FAKEVALUE > json: cannot unmarshal array into Go struct field TLSConfig.outbounds.streamSettings.tlsSettings.minVersion of type string
```

```console
Failed to start: main: failed to load config files: [config.json] > infra/conf/serial: failed to decode config: config.json > infra/conf/serial: failed to read
config file at line FAKEVALUE char FAKEVALUE > json: cannot unmarshal array into Go struct field TLSConfig.outbounds.streamSettings.tlsSettings.maxVersion of type string
```

```console
Failed to start: main: failed to load config files: [config.json] > infra/conf/serial: failed to decode config: config.json > infra/conf/serial: failed to read
config file at line FAKEVALUE char FAKEVALUE > json: cannot unmarshal array into Go struct field TLSConfig.outbounds.streamSettings.tlsSettings.cipherSuites of type string
```

</details>

我就怀疑文档写错了

源代码是这样写的

<details>

> https://github.com/XTLS/Xray-core/tree/main/infra/conf/transport_internet.go

```go
type TLSConfig struct {
	Insecure                         bool             `json:"allowInsecure"`
	Certs                            []*TLSCertConfig `json:"certificates"`
	ServerName                       string           `json:"serverName"`
	ALPN                             *StringList      `json:"alpn"`
	EnableSessionResumption          bool             `json:"enableSessionResumption"`
	DisableSystemRoot                bool             `json:"disableSystemRoot"`
	MinVersion                       string           `json:"minVersion"`
	MaxVersion                       string           `json:"maxVersion"`
	CipherSuites                     string           `json:"cipherSuites"`
	PreferServerCipherSuites         bool             `json:"preferServerCipherSuites"`
	Fingerprint                      string           `json:"fingerprint"`
	RejectUnknownSNI                 bool             `json:"rejectUnknownSni"`
	PinnedPeerCertificateChainSha256 *[]string        `json:"pinnedPeerCertificateChainSha256"`
}
```

</details>

以及文档开头的示例也是不带数组的

<hr />

另外我发现有一个字段叫做`preferServerCipherSuites`，翻了一下源代码好像没有发现用途，觉得可能是未实装的功能，就没写上去