### PR TITLE
修正docker image中geofiles的路径

### DIFF
--- a/docs/document/install.md
+++ b/docs/document/install.md
@@ -93,8 +93,8 @@ Linuxbrew 包管理器的使用方式与 Homebrew 一致：`brew install xray`
 
 - `/etc/xray/config.json`：配置文件
 - `/usr/bin/xray`：Xray 主程序
-- `/usr/local/share/xray/geoip.dat`：IP 数据文件
-- `/usr/local/share/xray/geosite.dat`：域名数据文件
+- `/usr/share/xray/geoip.dat`：IP 数据文件
+- `/usr/share/xray/geosite.dat`：域名数据文件
 
 # 图形化客户端
 


### PR DESCRIPTION
docker image中的geofiles路径错误
![image](https://github.com/XTLS/Xray-docs-next/assets/18255331/329c01b7-311f-4c42-bac0-f7a213216473)
