### PR TITLE
Change of URLs in Transport.MD so it won't change the locale

### DIFF
--- a/docs/config/transport.md
+++ b/docs/config/transport.md
@@ -355,7 +355,7 @@ CipherSuites 用于配置受支持的密码套件列表, 每个套件名称之�
 
 > `dest` : string
 
-必填，格式同 VLESS `fallbacks` 的 [dest](https://xtls.github.io/config/features/fallback.html#fallbackobject)。
+必填，格式同 VLESS `fallbacks` 的 [dest](./features/fallback.md#fallbackobject)。
 
 ::: warning
 为了伪装的效果考虑，Xray对于鉴权失败（非合法reality请求）的流量，会**直接转发**至 dest.
@@ -365,7 +365,7 @@ CipherSuites 用于配置受支持的密码套件列表, 每个套件名称之�
 
 > `xver` : number
 
-选填，格式同 VLESS `fallbacks` 的 [xver](https://xtls.github.io/config/features/fallback.html#fallbackobject)
+选填，格式同 VLESS `fallbacks` 的 [xver](./features/fallback.md#fallbackobject)
 
 > `serverNames` : \[string\]
 
@@ -411,7 +411,7 @@ CipherSuites 用于配置受支持的密码套件列表, 每个套件名称之�
 
 > `fingerprint` : string
 
-必填，同 [TLSObject](https://xtls.github.io/config/transport.html#tlsobject)。
+必填，同 [TLSObject](#tlsobject)。
 
 > `shortId` : string
 

--- a/docs/en/config/transport.md
+++ b/docs/en/config/transport.md
@@ -341,11 +341,11 @@ Emits verbose logs when `true`.
 
 > `dest`: string
 
-Required. Same schema as [dest](https://xtls.github.io/config/features/fallback.html#fallbackobject) in VLESS `fallbacks`.
+Required. Same schema as [dest](./features/fallback.md#fallbackobject) in VLESS `fallbacks`.
 
 > `xver`: string
 
-Optional. Same schema as [xver](https://xtls.github.io/config/features/fallback.html#fallbackobject) in VLESS `fallbacks`.
+Optional. Same schema as [xver](./features/fallback.md#fallbackobject) in VLESS `fallbacks`.
 
 > `serverNames`: [string]
 

--- a/docs/ru/config/transport.md
+++ b/docs/ru/config/transport.md
@@ -388,7 +388,7 @@ SHA256-хэш цепочки сертификатов удаленного се�
 
 > `dest`: string
 
-Обязательный параметр, формат такой же, как у `dest` в `fallbacks` для VLESS [dest](https://xtls.github.io/config/features/fallback.html#fallbackobject).
+Обязательный параметр, формат такой же, как у `dest` в `fallbacks` для VLESS [dest](./features/fallback.md#fallbackobject).
 
 ::: warning
 Для лучшей маскировки Xray **напрямую перенаправляет** трафик, не прошедший аутентификацию Reality (незаконные запросы Reality), на `dest`.  
@@ -398,7 +398,7 @@ SHA256-хэш цепочки сертификатов удаленного се�
 
 > `xver`: number
 
-Необязательный параметр, формат такой же, как у `xver` в `fallbacks` для VLESS [xver](https://xtls.github.io/config/features/fallback.html#fallbackobject).
+Необязательный параметр, формат такой же, как у `xver` в `fallbacks` для VLESS [xver](./features/fallback.md#fallbackobject).
 
 > `serverNames`: \[string\]
 
@@ -449,7 +449,7 @@ SHA256-хэш цепочки сертификатов удаленного се�
 
 > `fingerprint`: string
 
-Обязательный параметр, такой же, как в [TLSObject](https://xtls.github.io/config/transport.html#tlsobject).
+Обязательный параметр, такой же, как в [TLSObject](#tlsobject).
 
 > `shortId`: string
 


### PR DESCRIPTION
Currently these two hyperlinks in the file are leading to the version of the fallback page on Chinese language, so after clicking on the link users must change the locale again.
I suggest changing the URL in links so users would keep their current locale.