### PR TITLE
Remove double build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Install
+        run: pnpm install
       - name: Build for Main Repository
         env:
           NODE_OPTIONS: "--max_old_space_size=4096 --openssl-legacy-provider"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,22 +31,8 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Install and Build
-        env:
-          XRAY_DOCS_USE_VITE: "true"
-          NODE_OPTIONS: "--max_old_space_size=4096"
-        run: |
-          pnpm install
-          yarn docs:build
-      - name: Deploy
-        if: github.event_name != 'pull_request'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/.vuepress/dist
       - name: Build for Main Repository
         env:
-          XRAY_DOCS_MAIN_REPO: "true"
           NODE_OPTIONS: "--max_old_space_size=4096 --openssl-legacy-provider"
         run: |
           yarn docs:build

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -15,10 +15,8 @@ import i18nPlugin from "vuepress-plugin-i18n";
 const __dirname = getDirname(import.meta.url)
 console.log('>>> __dirname -> ', __dirname)
 const isProduction = process.env.NODE_ENV === "production";
-const forMainRepo = process.env.XRAY_DOCS_MAIN_REPO === "true";
 const useVite = process.env.XRAY_DOCS_USE_VITE === "true";
 
-console.log("base:", forMainRepo ? "/" : "/Xray-docs-next/");
 console.log(
   "bundler:",
   isProduction && !useVite ? "@vuepress/webpack" : "@vuepress/vite"
@@ -52,7 +50,7 @@ export default defineUserConfig(<UserConfig>{
       componentsDir: path.resolve(__dirname, './theme/components'),
     }),
   ],
-  base: forMainRepo ? "/" : "/Xray-docs-next/",
+  base: "/",
   locales: {
     "/": {
       lang: "zh-CN",


### PR DESCRIPTION
The docs are currently built twice, and as a result the docs also appear on https://xtls.github.io/Xray-docs-next/

This doesn't seem necessary and the gh-pages branch of this repo can be deleted. The real gh-pages branch is here:
https://github.com/XTLS/XTLS.github.io/tree/gh-pages-next

Deleting the gh-pages from this repo will also make clones faster

https://github.com/XTLS/Xray-docs-next/issues/560#issuecomment-2299019300