### PR TITLE
SplitHTTP: Reformat xmux config documentation

### DIFF
--- a/docs/config/transports/splithttp.md
+++ b/docs/config/transports/splithttp.md
@@ -89,9 +89,22 @@ SplitHTTP 的HTTP请求中所发送的host，默认值为空。若服务端值�
 
 设置为 `-1` 将完全禁用填充
 
-> `xmux`
+> `xmux`: [XmuxObject](#xmuxobject)
+
+## XmuxObject
+
+<Badge text="v24.9.19+" type="warning"/>
 
 允许用户对 SplitHTTP 在 h2 与 h3 中的多路复用行为进行控制，如不设置，默认行为为将所有请求复用至一条 TCP/QUIC 连接。
+
+```json
+{
+  "maxConcurrency": 0,
+  "maxConnections": 0,
+  "cMaxReuseTimes": 0,
+  "cMaxLifetimeMs": 0
+}
+```
 
 由于默认是无限复用，xmux 实际上是对此进行限制。此外不要启用 mux.cool.
 
@@ -99,13 +112,21 @@ SplitHTTP 的HTTP请求中所发送的host，默认值为空。若服务端值�
 - 流会复用物理连接，像这样 连接1(流1,流2,流3) 连接2(流4,流5,流6) .. 以此类推 在其他地方你可能看到 连接-子连接 这样的描述，都是一样的东西。
 - 下述所有字段类型均为 int/string 均支持固定值 `16` 或浮动值 `"8-32"` 的写法
 
-* `maxConcurrency`: 默认值为 0(即无限) 每个连接中复用的流的最大数量，连接中流的数量达到该值后核心会新建更多连接以容纳更多的流，类似于 mux.cool 的 concurrency.
+> `maxConcurrency`: int/string
 
-* `maxConnections`: 默认值为 0(即无限) 要打开的最大连接数，连接达到此值前核心会积极打开连接，对每一条流都新建一个连接，直到达到该值。然后核心会开始复用已经建立的连接。 与 `maxConcurrency` 冲突。
+默认值为 0(即无限) 每个连接中复用的流的最大数量，连接中流的数量达到该值后核心会新建更多连接以容纳更多的流，类似于 mux.cool 的 concurrency.
 
-* `cMaxReuseTimes`: 默认值为 0(即无限) 一个连接最多被复用几次，当达到该值后核心不会向该连接再分配流，其将在内部最后一条流关闭后断开。
+> `maxConnections`: int/string
 
-* `cMaxLifetimeMs`: 默认值为 0(即无限) 一个连接最多可以“存活”多久，当连接打开的时间超过该值后核心不会向该连接再分配流，其将在内部最后一条流关闭后断开。
+默认值为 0(即无限) 要打开的最大连接数，连接达到此值前核心会积极打开连接，对每一条流都新建一个连接，直到达到该值。然后核心会开始复用已经建立的连接。 与 `maxConcurrency` 冲突。
+
+> `cMaxReuseTimes`: int/string
+
+默认值为 0(即无限) 一个连接最多被复用几次，当达到该值后核心不会向该连接再分配流，其将在内部最后一条流关闭后断开。
+
+> `cMaxLifetimeMs`: int/string
+
+默认值为 0(即无限) 一个连接最多可以“存活”多久，当连接打开的时间超过该值后核心不会向该连接再分配流，其将在内部最后一条流关闭后断开。
 
 
 ## HTTP 版本

--- a/docs/en/config/transports/splithttp.md
+++ b/docs/en/config/transports/splithttp.md
@@ -109,23 +109,42 @@ A value of `-1` disables padding entirely.
 You can lower this to save bandwidth or increase it to improve censorship
 resistance. Too much padding may cause the CDN to reject traffic.
 
-> `xmux`
+> `xmux`: [XmuxObject](#xmuxobject)
 
-*Added in 24.9.16*
+## XmuxObject
+
+<Badge text="v24.9.19+" type="warning"/>
 
 Allows users to control the multiplexing behavior in h2 and h3. If not set, the default behavior is to multiplex all requests to one TCP/QUIC connection.
+
+```json
+{
+  "maxConcurrency": 0,
+  "maxConnections": 0,
+  "cMaxReuseTimes": 0,
+  "cMaxLifetimeMs": 0
+}
+```
 
 Since the default is unlimited reuse, `xmux` actually limits this. It's not recommended to enable `mux.cool` at the same time.
 
 Terminology: *Streams* will reuse physical connections, as in, one connection can hold many streams. In other places, streams are called sub-connections, they are the same thing.
 
-* `maxConcurrency`: Default 0 = infinite. The maximum number of streams reused in each connection. After the number of streams in the connection reaches this value, the core will create more connections to accommodate more streams, similar to the concurrency of mux.cool. Mutually exclusive with `maxConnections`.
+> `maxConcurrency`: int/string
 
-* `maxConnections`: Default 0 = infinite. The maximum number of connections to open. Every stream will open a new connection until this value is reached, only then connections will be reused. Mutually exclusive with `maxConcurrency`.
+Default 0 = infinite. The maximum number of streams reused in each connection. After the number of streams in the connection reaches this value, the core will create more connections to accommodate more streams, similar to the concurrency of mux.cool. Mutually exclusive with `maxConnections`.
 
-* `cMaxReuseTimes`: Default 0 = infinite. A connection can be reused at most several times. When this value is reached, the core will not allocate streams to the connection. It will be disconnected after the last internal stream is closed.
+> `maxConnections`: int/string
 
-* `cMaxLifetimeMs`: Default 0 = infinite. How long can a connection "survive" at most? When the connection is open for more than this value, the core will not redistribute streams to the connection, and it will be disconnected after the last internal stream is closed.
+Default 0 = infinite. The maximum number of connections to open. Every stream will open a new connection until this value is reached, only then connections will be reused. Mutually exclusive with `maxConcurrency`.
+
+> `cMaxReuseTimes`: int/string
+
+Default 0 = infinite. A connection can be reused at most several times. When this value is reached, the core will not allocate streams to the connection. It will be disconnected after the last internal stream is closed.
+
+> `cMaxLifetimeMs`: int/string
+
+Default 0 = infinite. How long can a connection "survive" at most? When the connection is open for more than this value, the core will not redistribute streams to the connection, and it will be disconnected after the last internal stream is closed.
 
 ## HTTP versions
 


### PR DESCRIPTION
The way that xmux is documented is inconsistent with other JSON objects, so let's make it more consistent. Later, XmuxObject should be moved outside of splithttp, but right now it really "belongs to" splithttp.

Also add/update version tags because 24.9.16 has broken xmux and people are getting confused.