### PR TITLE
Remove warp-plus mentions

### DIFF
--- a/docs/document/level-2/warp.md
+++ b/docs/document/level-2/warp.md
@@ -84,23 +84,7 @@ bash -c "$(curl -L wgcf-cli.vercel.app)"
 }
 ```
 - 完整文件将会保存到工作目录的 `wgcf.json` 内。
-3. 如果你还拥有一个 warp-plus 的密钥，你还可以运行 `wgcf-cli license -l [密钥]` 进行绑定
-- （密钥可以在[我们群](https://t.me/projectXray/)里发送 `/keyget@getwarpplusbot` 获取）输出：
-```json
-❯ wgcf-cli license -l 9zs5I61a-l9j8m7T5-4pC6k20X
-{
-    "id": "cd7f4695-e9ef-4bb0-b412-5f4d84919db7",
-    "created": "0001-01-01T00:00:00Z",
-    "updated": "2023-12-14T12:32:18.689777921Z",
-    "premium_data": 0,
-    "quota": 0,
-    "warp_plus": true,
-    "referral_count": 0,
-    "referral_renewal_countdown": 0,
-    "role": "child"
-}
-```
-4. 运行 `wgcf-cli generate --xray` 来生成一个WireGurad出站，他会将内容保存到 `wgcf.xray.json` 内
+3. 运行 `wgcf-cli generate --xray` 来生成一个WireGurad出站，他会将内容保存到 `wgcf.xray.json` 内
 - 示例文件：
 ```json
 {


### PR DESCRIPTION
warp-plus 已经无法注册，400 Bad Request。现移除warp-plus。而zero trust 由于(对于大部分人来说)需要信用卡，加上没有急切需要，暂不添加。