### PR TITLE
Fixed broken links, changed the `入站代理` to `入站协议` in the zhCN left-side menu

### DIFF
--- a/docs/.vuepress/config/sidebar/zh.ts
+++ b/docs/.vuepress/config/sidebar/zh.ts
@@ -32,7 +32,7 @@ export const sidebarZh: SidebarConfig = {
       ],
     },
     {
-      text: "入站代理",
+      text: "入站协议",
       children: [
         "/config/inbounds/dokodemo.md",
         "/config/inbounds/http.md",
@@ -45,7 +45,7 @@ export const sidebarZh: SidebarConfig = {
       ],
     },
     {
-      text: "出站代理",
+      text: "出站协议",
       children: [
         "/config/outbounds/blackhole.md",
         "/config/outbounds/dns.md",

--- a/docs/config/inbounds/index.md
+++ b/docs/config/inbounds/index.md
@@ -1,0 +1,12 @@
+# Xray 入站协议列表
+
+Xray 支持以下入站协议：
+
+- [Dokodemo-Door](../inbounds/dokodemo.md)
+- [HTTP](../inbounds/http.md)
+- [Shadowsocks](../inbounds/shadowsocks.md)
+- [Socks](../inbounds/socks.md)
+- [Trojan](../inbounds/trojan.md)
+- [VLESS (XTLS Vision Seed)](../inbounds/vless.md)
+- [VMess](../inbounds/vmess.md)
+- [WireGuard](../inbounds/wireguard.md)

--- a/docs/config/outbounds/index.md
+++ b/docs/config/outbounds/index.md
@@ -1,0 +1,15 @@
+# Xray 出站协议列表
+
+Xray 支持以下出站协议：
+
+- [Blackhole](../outbounds/blackhole.md)
+- [DNS](../outbounds/dns.md)
+- [Freedom (fragment, noises)](../outbounds/freedom.md)
+- [HTTP](../outbounds/http.md)
+- [Loopback](../outbounds/loopback.md)
+- [Shadowsocks](../outbounds/shadowsocks.md)
+- [Socks](../outbounds/socks.md)
+- [Trojan](../outbounds/trojan.md)
+- [VLESS (XTLS Vision Seed)](../outbounds/vless.md)
+- [VMess](../outbounds/vmess.md)
+- [WireGuard](../outbounds/wireguard.md)

--- a/docs/en/config/inbounds/index.md
+++ b/docs/en/config/inbounds/index.md
@@ -1,0 +1,12 @@
+# Xray Inbound Protocols List
+
+Xray supports the following inbound protocols:
+
+- [Dokodemo-Door](../inbounds/dokodemo.md)
+- [HTTP](../inbounds/http.md)
+- [Shadowsocks](../inbounds/shadowsocks.md)
+- [Socks](../inbounds/socks.md)
+- [Trojan](../inbounds/trojan.md)
+- [VLESS (XTLS Vision Seed)](../inbounds/vless.md)
+- [VMess](../inbounds/vmess.md)
+- [WireGuard](../inbounds/wireguard.md)

--- a/docs/en/config/outbounds/index.md
+++ b/docs/en/config/outbounds/index.md
@@ -1,0 +1,15 @@
+# Xray Outbound Protocols List
+
+Xray supports the following outbound protocols:
+
+- [Blackhole](../outbounds/blackhole.md)
+- [DNS](../outbounds/dns.md)
+- [Freedom (fragment, noises)](../outbounds/freedom.md)
+- [HTTP](../outbounds/http.md)
+- [Loopback](../outbounds/loopback.md)
+- [Shadowsocks](../outbounds/shadowsocks.md)
+- [Socks](../outbounds/socks.md)
+- [Trojan](../outbounds/trojan.md)
+- [VLESS (XTLS Vision Seed)](../outbounds/vless.md)
+- [VMess](../outbounds/vmess.md)
+- [WireGuard](../outbounds/wireguard.md)

--- a/docs/ru/config/inbounds/index.md
+++ b/docs/ru/config/inbounds/index.md
@@ -1,0 +1,12 @@
+# Список входящих протоколов Xray
+
+Xray поддерживает следующие входящие протоколы:
+
+- [Dokodemo-Door](../inbounds/dokodemo.md)
+- [HTTP](../inbounds/http.md)
+- [Shadowsocks](../inbounds/shadowsocks.md)
+- [Socks](../inbounds/socks.md)
+- [Trojan](../inbounds/trojan.md)
+- [VLESS (XTLS Vision Seed)](../inbounds/vless.md)
+- [VMess](../inbounds/vmess.md)
+- [WireGuard](../inbounds/wireguard.md)

--- a/docs/ru/config/outbounds/index.md
+++ b/docs/ru/config/outbounds/index.md
@@ -1,0 +1,15 @@
+# Список исходящих протоколов Xray
+
+Xray поддерживает следующие исходящие протоколы:
+
+- [Blackhole](../outbounds/blackhole.md)
+- [DNS](../outbounds/dns.md)
+- [Freedom (fragment, noises)](../outbounds/freedom.md)
+- [HTTP](../outbounds/http.md)
+- [Loopback](../outbounds/loopback.md)
+- [Shadowsocks](../outbounds/shadowsocks.md)
+- [Socks](../outbounds/socks.md)
+- [Trojan](../outbounds/trojan.md)
+- [VLESS (XTLS Vision Seed)](../outbounds/vless.md)
+- [VMess](../outbounds/vmess.md)
+- [WireGuard](../outbounds/wireguard.md)


### PR DESCRIPTION
https://xtls.github.io/config/inbound.html
顶部链接不可用，修改指向

然后中文的左侧菜单有歧义