### PR TITLE
CN DnsObject.clientIp also applies to DnsServerObject

### DIFF
--- a/docs/config/dns.md
+++ b/docs/config/dns.md
@@ -304,7 +304,7 @@ DNS 服务器端口，如 `53`。此项缺省时默认为 `53`。当使用 DOH�
 
 > `clientIP`: [string]
 
-EDNS Client Subnet 扩展中使用的 IP 地址。
+EDNS Client Subnet 扩展中使用的 IP 地址，覆盖全局 clientIP 选项。
 
 需要是一个有效的 IPv4 或者 IPv6. 实际发送时会自动抹掉最后几位，IPv4 和 IPv6 分别以 /24 和 /96 的子网发送。
 


### PR DESCRIPTION
clientIp 像 tag 一样
一旦它在全局中设置的话

所有服务器，包括 DnsServerObject 中未设置 clientIp 的服务器
一并生效

PS: 其它选项还有哪些是这样的我没试过，文档没说清楚，感觉要梳理