### PR TITLE
Update ch07-xray-server.md | Formatting fixes to English document 

### DIFF
--- a/docs/document/level-0/ch07-xray-server.md
+++ b/docs/document/level-0/ch07-xray-server.md
@@ -409,7 +409,7 @@ sudo systemctl enable xray
 
 6. 啰嗦了这么多，就是因为围绕 `BBR` 忽悠小白的错误概念和坑人脚本实在是太多了。我希望你们现在对 `BBR` 有了相对清晰的理解。接下来，我们就动手安装最新的 Debian 内核并开启`BBR` 吧！（真的很简单）
 
-1. 给 Debian 10 添加官方 `backports` 源，获取更新的软件库
+7. 给 Debian 10 添加官方 `backports` 源，获取更新的软件库
 
 ```shell
 sudo nano /etc/apt/sources.list
@@ -421,13 +421,13 @@ sudo nano /etc/apt/sources.list
 ，以此保证兼容性，也可避免默认文件在不可预见的情况下被覆盖而导致配置丢失。
 :::
 
-2.  然后把下面这一条加在最后，并保存退出。
+8.  然后把下面这一条加在最后，并保存退出。
 
 ```
 deb http://archive.debian.org/debian buster-backports main
 ```
 
-3.  刷新软件库并查询 Debian 官方的最新版内核并安装。请务必安装你的 VPS 对应的版本（本文以比较常见的【amd64】为例）。
+9.  刷新软件库并查询 Debian 官方的最新版内核并安装。请务必安装你的 VPS 对应的版本（本文以比较常见的【amd64】为例）。
 
 ```shell
 sudo apt update && sudo apt -t buster-backports install linux-image-amd64
@@ -444,7 +444,7 @@ sudo apt update && sudo apt -t buster-backports install linux-image-amd64
 
 :::
 
-4.  修改 `kernel` 参数配置文件 `sysctl.conf` 并指定开启 `BBR`
+10.  修改 `kernel` 参数配置文件 `sysctl.conf` 并指定开启 `BBR`
 
 ```shell
 sudo nano /etc/sysctl.conf
@@ -456,20 +456,20 @@ sudo nano /etc/sysctl.conf
 207 版本之后便不再从 `/etc/sysctl.conf` 读取参数。使用自定义配置文件也可避免默认文件在不可预见的情况下被覆盖而导致配置丢失。
 :::
 
-5.  把下面的内容添加进去
+11.  把下面的内容添加进去
 
 ```
 net.core.default_qdisc=fq
 net.ipv4.tcp_congestion_control=bbr
 ```
 
-6.  重启 VPS、使内核更新和`BBR`设置都生效
+12.  重启 VPS、使内核更新和`BBR`设置都生效
 
 ```shell
 sudo reboot
 ```
 
-7.  完整流程演示如下：
+13.  完整流程演示如下：
 
 ::: tip 啰嗦君
 因为我做展示的 VPS 支持云服务器专用内核，所以动图中我用了 `linux-image-cloud-amd64`
@@ -478,7 +478,7 @@ sudo reboot
 
 ![更新Debian内核并开启`BBR`](./ch07-img06-bbr-proper.gif)
 
-8.  确认`BBR`开启
+14.  确认`BBR`开启
 
 如果你想确认 `BBR` 是否正确开启，可以使用下面的命令：
 

--- a/docs/en/document/level-0/ch07-xray-server.md
+++ b/docs/en/document/level-0/ch07-xray-server.md
@@ -122,7 +122,9 @@ chmod +r ~/xray_cert/xray.key
 
     In addition, when recording animated images, the script did not include a command to restart `Xray` because `Xray` plans to support the [Certificate Hot Update] function, which means that `Xray` will automatically identify certificate updates and reload certificates without manual restart. After the function is added, I will modify `config.json` appropriately
     to enable this setting and delete the restart command in the script.
-    ::: 4. Add [executable] permissions to this file
+    :::
+
+    4. Add [executable] permissions to this file
 
         ```
         chmod +x ~/xray_cert/xray-cert-renew.sh
@@ -176,19 +178,21 @@ First, you can refer to the [official VLESS configuration example](https://githu
 
    ::: warning
    This location is not the standard log file location of `Xray`. It is placed here to avoid permission issues that cause trouble for new users. Once you are familiar with it, it is recommended to return to the default location: `/var/log/xray/access.log` and `/var/log/xray/error.log`.
-   ::: 4. Because Xray is used by the nobody user by default, we need to allow other users to have "write" permissions (`*.log` means all files with the suffix `log`, and the efficiency advantage of the `CLI` interface gradually appears at this time)
+   :::
+
+   4. Because Xray is used by the nobody user by default, we need to allow other users to have "write" permissions (`*.log` means all files with the suffix `log`, and the efficiency advantage of the `CLI` interface gradually appears at this time)
 
    ```shell
    chmod a+w ~/xray_log/*.log
    ```
 
-3. Use `nano` to create the configuration file of `Xray`
+   5. Use `nano` to create the configuration file of `Xray`
 
    ```shell
    sudo nano /usr/local/etc/xray/config.json
    ```
 
-4. Copy all the files below and fill in the previously generated `UUID` into the 61st line `"id": "",`. (After filling in, it will look like `"id": "uuiduuid-uuid-uuid-uuid-uuiduuiduuid"`
+6. Copy all the files below and fill in the previously generated `UUID` into the 61st line `"id": "",`. (After filling in, it will look like `"id": "uuiduuid-uuid-uuid-uuid-uuiduuiduuid"`
    ) This configuration file in this article adds my various verbose comments to help you understand the function of each configuration module.
 
 ```json
@@ -380,6 +384,7 @@ The stability of the kernel is the cornerstone of the stable operation of a serv
 
 ::: warning
 The so-called "leading" of the magic modification `bbr` is very time-sensitive. For example, many `bbrplus` scripts, because they have not been updated for several years, will still change your kernel to `4.19`. You should know that Debian is now stable and it is already the era of `5.9`. Then this script may be a little ahead in January 2018, but it has lost its meaning when 4.19 is released in October 2018. It can even be said to be completely [downgraded] and [degraded] now.
+:::
 
 4. Which of `fq`, `fq_codel`, `fq_pie`, `cake` and other algorithms is better?
 
@@ -391,7 +396,7 @@ In one sentence: **Don't use these! Throw them into the trash can of history! **
 
 It can only solve the problem of packet loss rate. A not very accurate analogy is that you originally used a car to deliver your goods, and sometimes the car broke down halfway (packet loss). After using these, you directly sent out 3 copies of the same goods and let three cars deliver them at the same time. As long as one of them is not broken, it can be delivered. The road is full of your cars, so you can naturally squeeze others out. But it is conceivable that when you squeeze others, others will also squeeze you, and the exit road of the entire computer room is so wide, and it is bound to become a collective traffic jam in the end.
 
-::: warning description
+::: warning Description
 Their principle is not algorithm optimization, not speed-up, most of them are simple and crude **multiple packet delivery**. It may be useful for bad lines with very high packet loss rates, but it has no optimization effect on good lines with low packet loss rates. Instead, it will consume your traffic exponentially, causing unnecessary pressure on the server and your neighbors.
 
 If your line really has a very high packet loss rate, the only reliable solution is to **change the line**.
@@ -404,11 +409,13 @@ If your line really has a very high packet loss rate, the only reliable solution
       sudo nano /etc/apt/sources.list
       ```
 
-   ::: warning description
+   ::: warning Description
    This article takes Debian 10 as an example, so there is still no problem using `/etc/apt/sources.list`, but if you are not starting from scratch according to this article, or using other Linux
    distributions, it is recommended that you create a `/etc/apt/sources.list.d/` folder and create your own configuration file in this folder, such as `/etc/apt/sources.list.d/vpsadmin.list`
    , to ensure compatibility and avoid the default file being overwritten in unforeseen circumstances and causing configuration loss.
-   ::: 2. Then add the following item at the end, save and exit.
+   :::
+
+   2. Then add the following item at the end, save and exit.
 
    ```
    deb http://deb.debian.org/debian buster-backports main
@@ -428,17 +435,21 @@ If your line really has a very high packet loss rate, the only reliable solution
    - Take a system snapshot before trying, or
    - You have `vnc` to save the day (and you know how to use it)
 
-   ::: 4. Modify the `kernel` parameter configuration file `sysctl.conf` and specify to enable `BBR`
+   :::
+
+   4. Modify the `kernel` parameter configuration file `sysctl.conf` and specify to enable `BBR`
 
    ```shell
    sudo nano /etc/sysctl.conf
    ```
 
-   ::: warning description
+   ::: warning Description
    This article takes Debian 10 as an example, so it is still no problem to use `/etc/sysctl.conf`, but if you are not following this article from scratch, or use other Linux distributions, it is recommended that you create a `/etc/sysctl.d/`
    folder and create your own configuration file in this folder, such as `/etc/sysctl.d/vpsadmin.conf`, to ensure compatibility, because some distributions no longer read parameters from `/etc/sysctl.conf` after `systemd`
    207 ​​version. Using a custom configuration file can also prevent the default file from being overwritten in unexpected circumstances, resulting in configuration loss.
-   ::: 5. Add the following content
+   :::
+
+   5. Add the following content
 
    ```
    net.core.default_qdisc=fq
@@ -462,19 +473,16 @@ If your line really has a very high packet loss rate, the only reliable solution
    ![Update Debian kernel and enable `BBR`](./ch07-img06-bbr-proper.gif) 8. Confirm that `BBR` is enabled
 
 If you want to confirm whether `BBR` is enabled correctly, you can use the following command:
-`shell
-    lsmod | grep bbr
-    `
+`lsmod | grep bbr`
+
 This should return the following result:
-`     tcp_bbr
-    `
+`tcp_bbr`
+
 If you want to confirm whether the `fq` algorithm is enabled correctly, you can use the following command:
-`shell
-    lsmod | grep fq
-    `
+`lsmod | grep fq`
+
 This should return the following result:
-`     sch_fq
-    `
+`sch_fq`
 
 ## 7.8 Server Optimization 2: Enable HTTP to automatically redirect to HTTPS
 

--- a/docs/en/document/level-0/ch07-xray-server.md
+++ b/docs/en/document/level-0/ch07-xray-server.md
@@ -186,13 +186,13 @@ First, you can refer to the [official VLESS configuration example](https://githu
    chmod a+w ~/xray_log/*.log
    ```
 
-   5. Use `nano` to create the configuration file of `Xray`
+3. Use `nano` to create the configuration file of `Xray`
 
-   ```shell
-   sudo nano /usr/local/etc/xray/config.json
-   ```
+```shell
+sudo nano /usr/local/etc/xray/config.json
+```
 
-6. Copy all the files below and fill in the previously generated `UUID` into the 61st line `"id": "",`. (After filling in, it will look like `"id": "uuiduuid-uuid-uuid-uuid-uuiduuiduuid"`
+4. Copy all the files below and fill in the previously generated `UUID` into the 61st line `"id": "",`. (After filling in, it will look like `"id": "uuiduuid-uuid-uuid-uuid-uuiduuiduuid"`
    ) This configuration file in this article adds my various verbose comments to help you understand the function of each configuration module.
 
 ```json

--- a/docs/en/document/level-0/ch07-xray-server.md
+++ b/docs/en/document/level-0/ch07-xray-server.md
@@ -403,76 +403,77 @@ If your line really has a very high packet loss rate, the only reliable solution
 :::
 
 6. I have said so much because there are too many misconceptions and scam scripts around `BBR` to fool novices. I hope you now have a relatively clear understanding of `BBR`. Next, let's install the latest Debian kernel and enable `BBR`! (It's really simple)
-   1. Add the official `backports` source to Debian 10 to get the updated software library
 
-      ```shell
-      sudo nano /etc/apt/sources.list
-      ```
+7. Add the official `backports` source to Debian 10 to get the updated software library
 
-   ::: warning Description
-   This article takes Debian 10 as an example, so there is still no problem using `/etc/apt/sources.list`, but if you are not starting from scratch according to this article, or using other Linux
-   distributions, it is recommended that you create a `/etc/apt/sources.list.d/` folder and create your own configuration file in this folder, such as `/etc/apt/sources.list.d/vpsadmin.list`
-   , to ensure compatibility and avoid the default file being overwritten in unforeseen circumstances and causing configuration loss.
-   :::
+```shell
+sudo nano /etc/apt/sources.list
+```
 
-   2. Then add the following item at the end, save and exit.
+::: warning Description
+This article takes Debian 10 as an example, so there is still no problem using `/etc/apt/sources.list`, but if you are not starting from scratch according to this article, or using other Linux
+distributions, it is recommended that you create a `/etc/apt/sources.list.d/` folder and create your own configuration file in this folder, such as `/etc/apt/sources.list.d/vpsadmin.list`
+, to ensure compatibility and avoid the default file being overwritten in unforeseen circumstances and causing configuration loss.
+:::
 
-   ```
-   deb http://deb.debian.org/debian buster-backports main
-   ```
+8. Then add the following item at the end, save and exit.
 
-   3. Refresh the software library and query the latest version of the official Debian kernel and install it. Please be sure to install the version corresponding to your VPS (this article takes the more common [amd64] as an example).
+```
+deb http://deb.debian.org/debian buster-backports main
+```
 
-      ```shell
-      sudo apt update && sudo apt -t buster-backports install linux-image-amd64
-      ```
+9. Refresh the software library and query the latest version of the official Debian kernel and install it. Please be sure to install the version corresponding to your VPS (this article takes the more common [amd64] as an example).
 
-   ::: warning Note
+  ```shell
+  sudo apt update && sudo apt -t buster-backports install linux-image-amd64
+  ```
 
-   If your VPS supports it, you can try the [cloud server dedicated kernel] `linux-image-cloud-amd64`. The advantages are simplicity and low resource usage. The disadvantage is that some students have reported that forced installation on an unsupported system will cause the system to fail to boot (the kernel cannot be recognized).
+::: warning Note
 
-   To avoid the tragedy of being unable to identify, please make sure:
-   - Take a system snapshot before trying, or
-   - You have `vnc` to save the day (and you know how to use it)
+If your VPS supports it, you can try the [cloud server dedicated kernel] `linux-image-cloud-amd64`. The advantages are simplicity and low resource usage. The disadvantage is that some students have reported that forced installation on an unsupported system will cause the system to fail to boot (the kernel cannot be recognized).
 
-   :::
+To avoid the tragedy of being unable to identify, please make sure:
+- Take a system snapshot before trying, or
+- You have `vnc` to save the day (and you know how to use it)
 
-   4. Modify the `kernel` parameter configuration file `sysctl.conf` and specify to enable `BBR`
+:::
 
-   ```shell
-   sudo nano /etc/sysctl.conf
-   ```
+10. Modify the `kernel` parameter configuration file `sysctl.conf` and specify to enable `BBR`
 
-   ::: warning Description
-   This article takes Debian 10 as an example, so it is still no problem to use `/etc/sysctl.conf`, but if you are not following this article from scratch, or use other Linux distributions, it is recommended that you create a `/etc/sysctl.d/`
-   folder and create your own configuration file in this folder, such as `/etc/sysctl.d/vpsadmin.conf`, to ensure compatibility, because some distributions no longer read parameters from `/etc/sysctl.conf` after `systemd`
-   207 ​​version. Using a custom configuration file can also prevent the default file from being overwritten in unexpected circumstances, resulting in configuration loss.
-   :::
+```shell
+sudo nano /etc/sysctl.conf
+```
 
-   5. Add the following content
+::: warning Description
+This article takes Debian 10 as an example, so it is still no problem to use `/etc/sysctl.conf`, but if you are not following this article from scratch, or use other Linux distributions, it is recommended that you create a `/etc/sysctl.d/`
+folder and create your own configuration file in this folder, such as `/etc/sysctl.d/vpsadmin.conf`, to ensure compatibility, because some distributions no longer read parameters from `/etc/sysctl.conf` after `systemd`
+207 ​​version. Using a custom configuration file can also prevent the default file from being overwritten in unexpected circumstances, resulting in configuration loss.
+:::
 
-   ```
-   net.core.default_qdisc=fq
-   net.ipv4.tcp_congestion_control=bbr
-   ```
+11. Add the following content
 
-   6. Restart the VPS to make the kernel update and `BBR` settings take effect
+```
+net.core.default_qdisc=fq
+net.ipv4.tcp_congestion_control=bbr
+```
 
-      ```shell
-      sudo reboot
-      ```
+12. Restart the VPS to make the kernel update and `BBR` settings take effect
 
-   7. The complete process is demonstrated as follows:
+  ```shell
+  sudo reboot
+  ```
 
-   ::: tip
-   Because the VPS I am demonstrating supports the cloud server-specific kernel, I used `linux-image-cloud-amd64` in the animation.
+13. The complete process is demonstrated as follows:
 
-   If you are not sure whether your VPS supports it, please follow the command in step 3 and use the regular kernel `linux-image-amd64`.
-   :::
+::: tip
+Because the VPS I am demonstrating supports the cloud server-specific kernel, I used `linux-image-cloud-amd64` in the animation.
 
-   ![Update Debian kernel and enable `BBR`](./ch07-img06-bbr-proper.gif) 
-   
-   8. Confirm that `BBR` is enabled
+If you are not sure whether your VPS supports it, please follow the command in step 3 and use the regular kernel `linux-image-amd64`.
+:::
+
+![Update Debian kernel and enable `BBR`](./ch07-img06-bbr-proper.gif) 
+
+14. Confirm that `BBR` is enabled
 
 If you want to confirm whether `BBR` is enabled correctly, you can use the following command:
 ```shell

--- a/docs/en/document/level-0/ch07-xray-server.md
+++ b/docs/en/document/level-0/ch07-xray-server.md
@@ -470,19 +470,29 @@ If your line really has a very high packet loss rate, the only reliable solution
    If you are not sure whether your VPS supports it, please follow the command in step 3 and use the regular kernel `linux-image-amd64`.
    :::
 
-   ![Update Debian kernel and enable `BBR`](./ch07-img06-bbr-proper.gif) 8. Confirm that `BBR` is enabled
+   ![Update Debian kernel and enable `BBR`](./ch07-img06-bbr-proper.gif) 
+   
+   8. Confirm that `BBR` is enabled
 
 If you want to confirm whether `BBR` is enabled correctly, you can use the following command:
-`lsmod | grep bbr`
+```shell
+lsmod | grep bbr
+```
 
 This should return the following result:
-`tcp_bbr`
+```
+tcp_bbr
+```
 
 If you want to confirm whether the `fq` algorithm is enabled correctly, you can use the following command:
-`lsmod | grep fq`
+```shell
+lsmod | grep fq
+```
 
 This should return the following result:
-`sch_fq`
+```
+sch_fq
+```
 
 ## 7.8 Server Optimization 2: Enable HTTP to automatically redirect to HTTPS
 


### PR DESCRIPTION
Hello! Sorry I had difficulties reading code of conduct provided in the repository, since my native tongue is not Chineese. Nonetheless, I have fixed formatting issues that cause problematic rendering of the text in English version. 

The page in question:  https://xtls.github.io/en/document/level-0/ch07-xray-server.html

<img width="723" height="827" alt="image" src="https://github.com/user-attachments/assets/edafaf95-d2a1-4f02-9e56-1db3133ae8ff" />

Here for example the warning block seems to be invalid and numbered points are rendered within warning block.

<img width="723" height="827" alt="image" src="https://github.com/user-attachments/assets/d085669a-f12b-48d4-b892-e2922ba41b8b" />

Same happened here further down the page. 
