### PR TITLE
Update ch07-xray-server.md

### DIFF
--- a/docs/document/level-0/ch07-xray-server.md
+++ b/docs/document/level-0/ch07-xray-server.md
@@ -520,7 +520,13 @@ sudo nano /etc/nginx/nginx.conf
 3. 在我们设置过的 80 端口 Server 中加入下面的语句，并保存退出（可同时删除`root`和`index`两行）
 
 ```
-return 301 https://$http_host$request_uri;
+location /.well-known/acme-challenge/ {
+   root /home/vpsadmin/www/webpage;
+}
+
+location / {
+   return 301 https://$host$request_uri;
+}
 ```
 
 4. 在与 `80` 端口同级的位置增加一个本地端口监听来提供网页展示。本文以 `8080` 端口做演示。（可以是任意端口）


### PR DESCRIPTION
acme.sh证书自动升级，遇到问题：
acme.sh --issue --server letsencrypt_test -d 你的域名 -w /home/vpsadmin/www/webpage --keylength ec-256 [Mon 25 Aug 2025 02:44:58 PM CST] Using CA: https://acme-staging-v02.api.letsencrypt.org/directory [Mon 25 Aug 2025 02:44:58 PM CST] Single domain='你的域名' [Mon 25 Aug 2025 02:44:58 PM CST] Getting webroot for domain='你的域名' [Mon 25 Aug 2025 02:44:58 PM CST] Verifying: 你的域名
[Mon 25 Aug 2025 02:44:59 PM CST] Pending. The CA is processing your order, please wait. (1/30) [Mon 25 Aug 2025 02:45:02 PM CST] 你的域名: Invalid status. Verification error details: 你的ip: Fetching https://你的域名/.well-known/acme-challenge/DD5WH431_lLbicABCDEFGabcdefgCJce1fXvP0PKUc: Error getting validation data [Mon 25 Aug 2025 02:45:02 PM CST] Please check log file for more details: /home/vpsadmin/.acme.sh/acme.sh.log

Let’s Encrypt 的 http-01 验证要求 必须能直接通过 HTTP 80 访问验证文件，不能跳转到 HTTPS，而教程上直接一刀切所有http直接301到https，Nginx 把 /.well-known/acme-challenge/ 路径也重定向到了 HTTPS，导致无法访问该文件，无法更新证书。

添加例外，问题解决