### PR TITLE
improve description for "autoSystemRoutingTable"

### DIFF
--- a/docs/config/inbounds/tun.md
+++ b/docs/config/inbounds/tun.md
@@ -63,6 +63,8 @@ userLevel 的值, 对应 [policy](../policy.md#policyobject) 中 `level` 的值.
 
 默认值为 `null`，即未配置。可填写具体接口名，也可填写 `"auto"` 让 Xray 自动选择。如果配置了 `autoSystemRoutingTable` 但未显式指定此项，Xray 会自动按 `"auto"` 处理。
 
+Xray 会为所有的出站都绑定选定的网络接口，配置了 `sendThrough` 或 `sockopt`->`interface` 的出站除外。
+
 ## 使用提示
 
 如果未配置 `autoSystemRoutingTable`，仍需要手动配置路由将数据导向创建的 TUN 接口，否则它只是个接口。
@@ -75,4 +77,6 @@ userLevel 的值, 对应 [policy](../policy.md#policyobject) 中 `level` 的值.
 注意可能的流量回环的问题，设置路由后可能将 Xray 发出的请求发回 Xray 造成回环！
 优先使用 `autoOutboundsInterface` 避免此问题；如果你需要手动控制，也可以使用 `sockopt` 中的 `interface` 绑定实际的物理网络接口。`ipconfig` (Windows) `ip a` (Linux) 将有助于找到你需要的接口名。
 或者使用出站的 `sendThrough` 它直接在 OutboundObject 中可用，没有 sockOpt.interface 那么深的嵌套层级，这里需要使用的是网卡上的 IP，比如 192.168.1.2 （如你所见它的缺点是不能自动支持双栈，请按你出站的实际使用的 IP 选择）。
+
+使用 `autoOutboundsInterface` 后，由于所有的出站都会被绑定选定的接口，出站不再能依赖系统路由表去将 `address`  路由到其所需的接口。如果 `address` 需要使用特定的接口，则需在出站中通过 `sendThrough` 或 `sockopt`->`interface` 手动指定。
 :::

--- a/docs/en/config/inbounds/tun.md
+++ b/docs/en/config/inbounds/tun.md
@@ -63,6 +63,8 @@ Automatically binds Xray outbounds to a physical network interface, so that traf
 
 The default value is `null`, which means not configured. You can specify an interface name explicitly, or use `"auto"` to let Xray choose one automatically. If `autoSystemRoutingTable` is configured but this field is omitted, Xray treats it as `"auto"`.
 
+Xray will bind all outbounds with the selected network interface, except those which set `sendThrough` or `sockopt`->`interface`.
+
 ## Usage Tips
 
 If `autoSystemRoutingTable` is not configured, you still need to add routes manually to direct traffic to the created TUN interface; otherwise, it remains just an interface.
@@ -75,4 +77,6 @@ If you only want to proxy specific process(es), the process name routing in the 
 Be aware of potential traffic loop issues. After setting routes, requests initiated by Xray might be sent back to Xray, causing a loop!
 Prefer `autoOutboundsInterface` to avoid this problem. If you need manual control, you can still use `interface` in `sockopt` to bind to the actual physical network interface. `ipconfig` (Windows) or `ip a` (Linux) will help you find the interface name you need.
 Alternatively, use the outbound `sendThrough` setting. It is available directly in `OutboundObject` without the deep nesting level of `sockOpt.interface`. Here you need to use the IP address on the network card, such as 192.168.1.2 (As you can see, its disadvantage is that it cannot automatically support dual-stack; please choose according to the IP actually used for your outbound connection).
+
+With `autoOutboundsInterface`, as outbounds are bound to the selected network interface, outbounds cannot rely on system route table to route `address` to its desired interface. If `address` needs to use a specific interface, you need to set so manually using `sendThrough` or `sockopt`->`interface` in the outbound .
 :::


### PR DESCRIPTION
explain the logic of "autoSystemRoutingTable", and add warning for outbounds that need specific interfaces.

related to: https://github.com/XTLS/Xray-core/issues/6269