### PR TITLE
Add IPv6 warning for wget in certificates.md

### DIFF
--- a/docs/ru/document/level-0/ch06-certificates.md
+++ b/docs/ru/document/level-0/ch06-certificates.md
@@ -26,6 +26,14 @@
    ```shell
    wget -O -  https://get.acme.sh | sh
    ```
+::: warning
+Если команда зависает с ошибкой вида
+`Connecting to get.acme.sh (get.acme.sh)|2606:4700:20::...443... failed: Connection timed out`
+— скорее всего, на вашем сервере не работает IPv6, и wget пытается подключиться через него.
+Принудительно используйте IPv4, добавив флаг `-4`:
+
+    wget -4 -O - https://get.acme.sh | sh
+:::
 
 3. Сделайте команду `acme.sh` доступной:
 


### PR DESCRIPTION
## Problem
On servers with broken/unconfigured IPv6, the acme.sh installation command
from the Russian level-0 guide (ch06) hangs with connection timeouts,
because wget tries IPv6 addresses first:
<img width="1037" height="144" alt="timeout" src="https://github.com/user-attachments/assets/a9d4d112-65c6-460c-995e-9a2d9cd18a35" />

## Change
Added a warning block to the Russian docs (ch06-certificates.md) suggesting
the `-4` flag to force IPv4 when this timeout occurs.
